### PR TITLE
Move or copy emails from one account to another

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,6 +94,7 @@
                             RSS feeds), as well as standard E-mail client folder navigation</li>
                         <li>Flexible profiles to combined IMAP accounts with SMTP accounts and setup signatures and
                             reply to details</li>
+                        <li>Move or copy emails from one account to another</li>
                         <li>Compose messages in plain text, HTML, or Markdown (markdown formatted messages are converted
                             to HTML before being sent)</li>
                     </ul>


### PR DESCRIPTION
Adding after section which talks about IMAP accounts because it's related.

This is one of my favorite features, and other popular webmails do not support it. Ex.:
https://github.com/roundcube/roundcubemail/issues/4972