### PR TITLE
fix a command which required root access

### DIFF
--- a/install.html
+++ b/install.html
@@ -115,7 +115,7 @@ sudo mkdir /var/lib/hm3/attachments
 sudo mkdir /var/lib/hm3/users
 sudo mkdir /var/lib/hm3/app_data
 
-chown -R www-data /var/lib/hm3/
+sudo chown -R www-data /var/lib/hm3/
       </pre>
       <p>The /var/lib/hm3/users directory is only required if you are using the file-system and not a database to store user settings (user_config_type = file in the hm3.ini). You can put these directories anywhere, just make sure the values in the ini file point to the right place.
       </p>


### PR DESCRIPTION
Hello, this is Revisto from Wikisuite Project.
I changed this command line "chown -R www-data /var/lib/hm3/" which required root access so it has to be used with a "sudo" at the start.