### PR TITLE
Fix/og image preview

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,19 @@ prod:
 	php cecil.phar build
 	php scripts/bundle-css.php
 
+# Demo/staging build: identical to `prod`, but the base URL comes from Cecil's
+# native CECIL_BASEURL env override (not cecil.yml), so the social-share tags
+# (og:image, og:url, canonical) resolve on the deploy domain.
+#
+# The domain is NOT hard-coded. Override it per deploy without editing this file:
+#   CECIL_BASEURL=https://your-new-domain.example/ make demo
+# The same variable works with any build command (e.g. in CI):
+#   CECIL_BASEURL=https://your-new-domain.example/ make prod
+.PHONY: demo
+demo:
+	CECIL_BASEURL="$${CECIL_BASEURL:-https://demo.cypht.lab15.evoludata.com/}" php cecil.phar build
+	php scripts/bundle-css.php
+
 # Preview the production build locally WITH working <video> (Range support,
 # which `php -S` alone lacks). Run `make prod` first. → http://127.0.0.1:8080
 .PHONY: preview

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ prod:
 #   CECIL_BASEURL=https://your-new-domain.example/ make prod
 .PHONY: demo
 demo:
-	CECIL_BASEURL="$${CECIL_BASEURL:-https://demo.cypht.lab15.evoludata.com/}" php cecil.phar build
+	CECIL_BASEURL="$${CECIL_BASEURL:-https://cypht.org/}" php cecil.phar build
 	php scripts/bundle-css.php
 
 # Preview the production build locally WITH working <video> (Range support,

--- a/static/installation/manual.md
+++ b/static/installation/manual.md
@@ -10,8 +10,7 @@
       </div>
       <div class="g-card-body">
          <p>
-            <a href="https://github.com/cypht-org/cypht/tree/1.4.x">Cypht 1.4.x</a> requires PHP 5.6 to 7.4. For PHP 8.1+, please use
-            <a href="https://github.com/cypht-org/cypht/tree/2.x">Cypht 2.x+</a>, <a href="https://getcomposer.org/">Composer 2</a>, and at minimum the
+            <a href="https://github.com/cypht-org/cypht/tree/1.4.x">Cypht 2.x</a> requires PHP 8.1+, <a href="https://getcomposer.org/">Composer 2</a>, and at minimum the
             <a href="http://php.net/manual/en/book.openssl.php">OpenSSL</a>, <a href="http://php.net/manual/en/book.mbstring.php">mbstring</a> and
             <a href="http://php.net/manual/en/book.curl.php">cURL</a> extensions. Cypht can also leverage several other extensions as defined in
             <a href="https://github.com/cypht-org/cypht/blob/1.4.x/composer.json#L37-L44">composer.json</a>. Testing is done on               <a href="https://www.debian.org/">Debian</a> and <a href="http://www.ubuntu.com/">Ubuntu</a> platforms with


### PR DESCRIPTION
## Why

Sharing a page link showed a **blank preview image**. The Open Graph tags (`og:image`, `og:url`, `canonical`) are built from `baseurl` in `cecil.yml`, pinned to production — so on any other deploy they pointed to the prod host where the image 404s.

## Changes

 **`Makefile`**: add a `make demo` target that sets the base URL via Cecil's native `CECIL_BASEURL` env var. The domain isn't hard-coded — override it per deploy: `CECIL_BASEURL=https://your-domain/ make demo`. `make prod` is untouched.